### PR TITLE
Update main.bicep with optimised start command

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -48,7 +48,7 @@ module web 'core/host/appservice.bicep' = {
     location: location
     tags: union(tags, { 'azd-service-name': 'app' })
     appServicePlanId: appServicePlan.outputs.id
-    appCommandLine: 'python -m uvicorn app.main:app --host 0.0.0.0'
+    appCommandLine: 'python -m gunicorn -w 2 -k uvicorn.workers.UvicornWorker  --timeout 60 --access-logfile '-' --error-logfile '-' --bind=0.0.0.0:8000 app.main:app'
     runtimeName: 'python'
     runtimeVersion: '3.11'
     scmDoBuildDuringDeployment: true


### PR DESCRIPTION
Ideally uvicorn should be started via gunicorn --  https://www.uvicorn.org/deployment/

The B1 SKU I recommend running 2 workers. 
These access and error log file flags will use stdout so the log view in vs code and the portal will work.